### PR TITLE
Invoke callback with null arg to cancel the action

### DIFF
--- a/android/src/main/java/com/oblongmana/webviewfileuploadandroid/AndroidWebViewManager.java
+++ b/android/src/main/java/com/oblongmana/webviewfileuploadandroid/AndroidWebViewManager.java
@@ -118,6 +118,7 @@ public class AndroidWebViewManager extends ReactWebViewManager {
                         module.setActivityEventListener(null);
 
                         if (resultCode != Activity.RESULT_OK) {
+                            fileUriCallback.onReceiveValue(null);
                             return;
                         }
 


### PR DESCRIPTION
If the result is not okay, we send a callback to the web view with a null value. This indicates that the action was cancelled.